### PR TITLE
Adding redo shortcut mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,4 @@ You can read more about how to contribute keybindings in extensions in the [offi
 | workbench.action.openGlobalSettings | cmd+, | ctrl+, | ctrl+, |
 | workbench.action.showAllEditors | cmd+b | ctrl+b | ctrl+b |
 | workbench.action.toggleZenMode | cmd+ctrl+shift+f | shift+f11 | shift+f11 |
+| redo | cmd+y | ctrl+y | ctrl+y |

--- a/package.json
+++ b/package.json
@@ -517,6 +517,13 @@
                 "linux": "shift+f11",
                 "key": "shift+f11",
                 "command": "workbench.action.toggleZenMode"
+            },
+            {
+                "mac": "cmd+y",
+                "win": "ctrl+y",
+                "linux": "ctrl+y",
+                "key": "ctrl+y",
+                "command": "redo"
             }
         ],
         "configuration": {


### PR DESCRIPTION
Replacing VS redo shortcut `shift+cmd+z` by Atom command `cmd+y`