### PR TITLE
Add cmd/ctrl+p binding for quickOpenPreviousEditor

### DIFF
--- a/package.json
+++ b/package.json
@@ -531,6 +531,13 @@
                 "win": "ctrl+j",
                 "key": "ctrl+j",
                 "command": "editor.action.joinLines"
+            },
+            {
+                "mac": "cmd+p",
+                "win": "ctrl+p",
+                "linux": "ctrl+p",
+                "key": "ctrl+p",
+                "command": "workbench.action.quickOpenPreviousEditor"
             }
         ],
         "configuration": {


### PR DESCRIPTION
fixes https://github.com/Microsoft/vscode-atom-keybindings/issues/43