### PR TITLE
Fix copying from terminal on Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -481,7 +481,8 @@
                 "win": "ctrl+shift+c",
                 "linux": "ctrl+shift+c",
                 "key": "ctrl+shift+c",
-                "command": "workbench.action.files.copyPathOfActiveFile"
+                "command": "workbench.action.files.copyPathOfActiveFile",
+                "when": "!terminalFocus"
             },
             {
                 "mac": "cmd+,",


### PR DESCRIPTION
I've reproduced this issue on Linux, it may also affect Windows.

### How to test

- Open integrated terminal, select some text and press `ctrl+shift+c`.

### Expected behavior

- Selected text is copied to clipboard.

### Actual behavior

- The path to the previously active file (before focusing the integrated terminal) is copied to clipboard.