### PR TITLE
allow to run in untrusted workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
         "workspace"
     ],
     "main": "./extension",
+    "capabilities": {
+        "untrustedWorkspaces": {
+            "supported": true
+        }
+    },
     "contributes": {
         "keybindings": [
             {


### PR DESCRIPTION
Since this extension only provides keybindings, it is safe to run in untrusted workspaces. fix #74