### PR TITLE
Adopt Settings Defaults

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,96 +1,9 @@
 const vscode = require('vscode');
 
-const showInformationMessage = vscode.window.showInformationMessage;
-const isGlobalConfigValue = true;
-
-class Setting {
-    constructor(name, value) {
-        this.name = name;
-        this.value = value;
-    }
-}
-
-const versionThreeSettings = [
-    new Setting('multiCursorModifier', 'ctrlCmd'),
-    new Setting('formatOnPaste', true)
-];
-
-function updateSettings(editorConfig, settings) {
-    settings.forEach((setting) => {
-        editorConfig.update(setting.name, setting.value, isGlobalConfigValue);
-    });
-}
-
-function isDefaultValueSet(editorConfig, settings) {
-    for (var i = 0; i < settings.length; i++) {
-        var setting = editorConfig.inspect(settings[i].name);
-        const dv = setting ? setting.defaultValue : null;
-        const gv = setting ? setting.globalValue : null;
-
-        if (gv === dv || gv === undefined) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-class VersionThreeUpdateSetting {
-    constructor() {
-        this.name = 'promptV3Features';
-        this.config = vscode.workspace.getConfiguration('atomKeymap');
-        this.hasPrompted = this.config.get(this.name) || false;
-    }
-
-    persist() {
-        this.config.update(this.name, true, isGlobalConfigValue);
-    }
-
-}
-
-class View {
-    constructor(updateSetting, editorConfig) {
-        this.updateSetting = updateSetting;
-        this.editorConfig = editorConfig;
-        this.messages = {
-            yes: 'Yes',
-            no: 'No',
-            learnMore: 'Learn More',
-            prompt: 'New features are available for Atom Keymap 3.0. Do you want to enable the new features?',
-            noChange: 'Atom Keymap: New features have not been enabled.',
-            change: 'Atom Keymap: New features have been added.',
-        };
-    }
-
-    showMessage() {
-        const answer = showInformationMessage(this.messages.prompt, this.messages.yes, this.messages.no, this.messages.learnMore);
-
-        answer.then((selectedOption) => {
-            if (selectedOption === this.messages.yes) {
-                this.updateSetting.persist();
-                updateSettings(this.editorConfig, versionThreeSettings);
-                showInformationMessage(this.messages.change);
-            } else if (selectedOption === this.messages.no) {
-                this.updateSetting.persist();
-                showInformationMessage(this.messages.noChange);
-            } else if (selectedOption === this.messages.learnMore) {
-                vscode.commands.executeCommand('vscode.open', vscode.Uri.parse('https://marketplace.visualstudio.com/items?itemName=ms-vscode.atom-keybindings'));
-            }
-        });
-    }
-}
-
 const activate = async () => {
     // VSCode using new explorer filtration since v1.31
     // so we need to use context key for proper use of hotkeys with single key like `A` or `^A`
     await vscode.commands.executeCommand('setContext', 'listAutomaticKeyboardNavigation', false);
-
-    const editorConfig = vscode.workspace.getConfiguration('editor');
-    const updateSetting = new VersionThreeUpdateSetting();
-
-    if (!updateSetting.hasPrompted && isDefaultValueSet(editorConfig, versionThreeSettings)) {
-        new View(updateSetting, editorConfig).showMessage();
-    }
 }
 
 module.exports = { activate };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "atom-keybindings",
-    "version": "3.0.9",
+    "version": "3.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "atom-keybindings",
     "displayName": "Atom Keymap",
     "description": "Popular Atom keybindings for Visual Studio Code",
-    "version": "3.0.10",
+    "version": "3.1.0",
     "publisher": "ms-vscode",
     "engines": {
         "vscode": "^1.22.0"
@@ -550,19 +550,9 @@
                 "when": "terminalFocus"
             }
         ],
-        "configuration": {
-            "type": "object",
-            "title": "Atom Keymap configuration",
-            "properties": {
-                "atomKeymap.promptV3Features": {
-                    "type": [
-                        "boolean",
-                        "null"
-                    ],
-                    "default": null,
-                    "description": "Status of Atom Keymap version three features added."
-                }
-            }
+        "configurationDefaults": {
+            "editor.multiCursorModifier": "ctrlCmd",
+            "editor.formatOnPaste": true
         }
     },
     "scripts": {


### PR DESCRIPTION
I did this with the hopes of maybe getting this extension off of `*` activation but it seems that that is not possible at the moment due to this line:

https://github.com/microsoft/vscode-atom-keybindings/blob/774ea475670089b0095b02cd46133021ac805df1/extension.js#L6

Maybe if that behavior could be a VS Code setting, then we can completely remove the code from this extension.