### PR TITLE
Get rid of code since settings defaults are sufficient in 1.75

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,9 +1,0 @@
-const vscode = require('vscode');
-
-const activate = async () => {
-    // VSCode using new explorer filtration since v1.31
-    // so we need to use context key for proper use of hotkeys with single key like `A` or `^A`
-    await vscode.commands.executeCommand('setContext', 'listAutomaticKeyboardNavigation', false);
-}
-
-module.exports = { activate };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,18 @@
 {
     "name": "atom-keybindings",
-    "version": "3.2.0",
+    "version": "3.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "atom-keybindings",
-            "version": "3.2.0",
+            "version": "3.3.0",
             "license": "MIT",
             "devDependencies": {
-                "@types/vscode": "^1.30.0",
                 "@vscode/test-web": "^0.0.33"
             },
             "engines": {
-                "vscode": "^1.30.0"
+                "vscode": "^1.75.0"
             }
         },
         "node_modules/@koa/cors": {
@@ -51,12 +50,6 @@
             "engines": {
                 "node": ">= 10"
             }
-        },
-        "node_modules/@types/vscode": {
-            "version": "1.74.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
-            "integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
-            "dev": true
         },
         "node_modules/@vscode/test-web": {
             "version": "0.0.33",
@@ -1461,12 +1454,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
             "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-            "dev": true
-        },
-        "@types/vscode": {
-            "version": "1.74.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
-            "integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
             "dev": true
         },
         "@vscode/test-web": {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
     "name": "atom-keybindings",
     "displayName": "Atom Keymap",
     "description": "Popular Atom keybindings for Visual Studio Code",
-    "version": "3.2.0",
+    "version": "3.3.0",
     "publisher": "ms-vscode",
     "engines": {
-        "vscode": "^1.30.0"
+        "vscode": "^1.75.0"
     },
     "license": "MIT",
     "categories": [
@@ -17,20 +17,10 @@
     ],
     "preview": true,
     "icon": "atom-keyboard-padded.png",
-    "activationEvents": [
-        "*"
-    ],
     "extensionKind": [
         "ui",
         "workspace"
     ],
-    "main": "./extension",
-    "browser": "./extension",
-    "capabilities": {
-        "untrustedWorkspaces": {
-            "supported": true
-        }
-    },
     "contributes": {
         "keybindings": [
             {
@@ -553,14 +543,14 @@
         ],
         "configurationDefaults": {
             "editor.multiCursorModifier": "ctrlCmd",
-            "editor.formatOnPaste": true
+            "editor.formatOnPaste": true,
+            "workbench.list.typeNavigationMode": "trigger"
         }
     },
     "scripts": {
         "open-in-browser": "vscode-test-web --extensionDevelopmentPath=. ."
     },
     "devDependencies": {
-        "@types/vscode": "^1.30.0",
         "@vscode/test-web": "^0.0.33"
     },
     "repository": {


### PR DESCRIPTION
cc @joyceerhl for no more activation event

cc @sbatten for removal of workspace trust since there is no longer code in here it works regardless.

cc @joaomoreno for adding the setting