### PR TITLE
Adds windows  shortcut for "editor.action.commentLine"

### DIFF
--- a/package.json
+++ b/package.json
@@ -318,6 +318,7 @@
             },
             {
                 "mac": "cmd+shift+7",
+                "win": "alt+shift+7",
                 "key": "cmd+k cmd+c",
                 "command": "editor.action.commentLine",
                 "when": "editorTextFocus"


### PR DESCRIPTION
Justs adds:

```json
            {
                "mac": "cmd+shift+7",
                "win": "alt+shift+7",
                "key": "cmd+k cmd+c",
                "command": "editor.action.commentLine",
                "when": "editorTextFocus"
            }
```

